### PR TITLE
Update mcd-sel-fj.py anchor tag selector

### DIFF
--- a/.github/workflows/scrape-fj-auto.yml
+++ b/.github/workflows/scrape-fj-auto.yml
@@ -26,9 +26,9 @@ jobs:
         patterns: ./mcd-sel-fj
 
     - name: setup python
-      uses: actions/setup-python@v2
-#       with:
-#         python-version: 3.8.2
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
     - name: setup dependencies
       working-directory: ./mcd-sel-fj
       run: |

--- a/.github/workflows/scrape-fj-manual.yml
+++ b/.github/workflows/scrape-fj-manual.yml
@@ -26,9 +26,9 @@ jobs:
               patterns: ./mcd-sel-fj
 
           - name: setup python
-            uses: actions/setup-python@v2
-#             with:
-#                 python-version: 3.8.2
+            uses: actions/setup-python@v4
+            with:
+                python-version: '3.11'
           - name: setup dependencies
             working-directory: ./mcd-sel-fj
             run: |

--- a/mcd-sel-fj/mcd-sel-fj.py
+++ b/mcd-sel-fj/mcd-sel-fj.py
@@ -98,7 +98,7 @@ try:
                 r"[a-zA-Z]+",
                 ((browser.find_element(
                     By.CSS_SELECTOR,
-                    f'nav.scrollspy-menu a[data-slug="{category_id}"]'
+                    f'nav.scrollspy-menu a[href="#{category_id}"]'
                 )).text)
             )
         )

--- a/mcd-sel-fj/scraped-data/[2023-07-04 04:21:48] mcd-sel-fj.csv
+++ b/mcd-sel-fj/scraped-data/[2023-07-04 04:21:48] mcd-sel-fj.csv
@@ -1,0 +1,34 @@
+,Date,Day,Territory,Menu Item,Price (FJD),Price (USD),Category,Menu
+1,2023/07/04,Tue,Fiji,Big Mac (S/R) -Beef,14.55,6.53,Classic McValue Meals,Regular
+2,2023/07/04,Tue,Fiji,Cheeseburger (S/R) - Beef,10.95,4.92,Classic McValue Meals,Regular
+3,2023/07/04,Tue,Fiji,Filet-O-Fish (S/R),12.15,5.45,Classic McValue Meals,Regular
+4,2023/07/04,Tue,Fiji,Double Cheeseburger (S/R) - Beef,13.95,6.26,Classic McValue Meals,Regular
+5,2023/07/04,Tue,Fiji,Salad Burger (S/R),10.95,4.92,Classic McValue Meals,Regular
+6,2023/07/04,Tue,Fiji,Filet McWrap (S/R),13.85,6.22,Classic McValue Meals,Regular
+7,2023/07/04,Tue,Fiji,McChicken (S/R),14.35,6.44,Chicken Mcvalue Meals,Regular
+8,2023/07/04,Tue,Fiji,2pc Hot And Spicy (S/R),14.15,6.35,Chicken Mcvalue Meals,Regular
+9,2023/07/04,Tue,Fiji,3pc Hot And Spicy (S/R),19.10,8.57,Chicken Mcvalue Meals,Regular
+10,2023/07/04,Tue,Fiji,5pc Hot And Spicy (S/R),27.70,12.43,Chicken Mcvalue Meals,Regular
+11,2023/07/04,Tue,Fiji,6pk McNuggets (S/R),13.50,6.06,Chicken Mcvalue Meals,Regular
+12,2023/07/04,Tue,Fiji,10pk McNuggets (S/R),16.35,7.34,Chicken Mcvalue Meals,Regular
+13,2023/07/04,Tue,Fiji,Chicken Aioli McWrap (S/R),13.95,6.26,Chicken Mcvalue Meals,Regular
+14,2023/07/04,Tue,Fiji,Cheeseburger Happy Meal (Beef),12.65,5.68,Happy Meals,Regular
+15,2023/07/04,Tue,Fiji,Junior Burger Happy Meal (Beef),12.65,5.68,Happy Meals,Regular
+16,2023/07/04,Tue,Fiji,4pk Chicken McNuggets Happy Meal,12.65,5.68,Happy Meals,Regular
+17,2023/07/04,Tue,Fiji,Big Mac (Beef),10.15,4.56,Classic Favourites,Regular
+18,2023/07/04,Tue,Fiji,Cheeseburger (Beef),6.55,2.94,Classic Favourites,Regular
+19,2023/07/04,Tue,Fiji,Filet-O-Fish,7.65,3.43,Classic Favourites,Regular
+20,2023/07/04,Tue,Fiji,Double Cheeseburger (Beef),10.25,4.60,Classic Favourites,Regular
+21,2023/07/04,Tue,Fiji,Salad Burger,7.45,3.34,Classic Favourites,Regular
+22,2023/07/04,Tue,Fiji,Vege McWrap,9.85,4.42,Classic Favourites,Regular
+23,2023/07/04,Tue,Fiji,Filet McWrap,10.25,4.60,Classic Favourites,Regular
+24,2023/07/04,Tue,Fiji,3pc Hot And Spicy Chicken,15.15,6.80,Chicken Favourites,Regular
+25,2023/07/04,Tue,Fiji,5pc Hot And Spicy Chicken,24.25,10.89,Chicken Favourites,Regular
+26,2023/07/04,Tue,Fiji,6pk McNuggets,7.95,3.57,Chicken Favourites,Regular
+27,2023/07/04,Tue,Fiji,10pk McNuggets,11.95,5.36,Chicken Favourites,Regular
+28,2023/07/04,Tue,Fiji,Mc Chicken,9.75,4.38,Chicken Favourites,Regular
+29,2023/07/04,Tue,Fiji,Chicken Aioli McWrap,10.95,4.92,Chicken Favourites,Regular
+30,2023/07/04,Tue,Fiji,Sweet And Sour Sauce,0.50,0.22,Sides And Condiments,Regular
+31,2023/07/04,Tue,Fiji,Ketchup Packet,0.25,0.11,Sides And Condiments,Regular
+32,2023/07/04,Tue,Fiji,BBQ Sauce,0.50,0.22,Sides And Condiments,Regular
+33,2023/07/04,Tue,Fiji,Fries (S/R),4.15,1.86,Sides And Condiments,Regular


### PR DESCRIPTION
Changed attribute in anchor tag selector from `data-slug` to `href` and prepended value with `#` in accordance with order webpage updates.