### PR TITLE
Fix Scrapy issues with OpenSSL 

### DIFF
--- a/.github/workflows/scrape-bn-auto.yml
+++ b/.github/workflows/scrape-bn-auto.yml
@@ -25,19 +25,19 @@ jobs:
     - name: checkout repo content
       uses: actions/checkout@v3       # checkout the repository content to github runner.
     - name: setup python
-      uses: actions/setup-python@v4
-#       with:
-#         python-version: 3.8.2
+      uses: actions/setup-python@v5
+      with:
+          python-version: '3.12'
     - name: setup dependencies
       working-directory: ./mcd-scr-bn
       run: |
-        pip3 install scrapy==2.6.1
+        pip3 install scrapy==2.11.2
         pip3 install pandas 
         pip3 install pytz
         pip3 install path
         pip3 install pathlib2
-        pip3 install pyopenssl
-#       pip3 install pyopenssl==22.0.0
+        pip3 install pyopenssl==22.0.0
+        pip3 install cryptography==37.0.4 --ignore-installed
     - name: execute py script       # run mcd-scr-bn.py to get the latest data
       working-directory: ./mcd-scr-bn
       run: |

--- a/.github/workflows/scrape-hk-auto.yml
+++ b/.github/workflows/scrape-hk-auto.yml
@@ -24,19 +24,19 @@ jobs:
     - name: checkout repo content
       uses: actions/checkout@v3       # checkout the repository content to github runner.
     - name: setup python
-      uses: actions/setup-python@v4
-#       with:
-#         python-version: 3.8.2
+      uses: actions/setup-python@v5
+      with:
+          python-version: 3.8.2
     - name: setup dependencies
       working-directory: ./mcd-scr-hk
       run: |
-        pip3 install scrapy==2.6.1
+        pip3 install scrapy==2.11.2
         pip3 install pandas 
         pip3 install pytz
         pip3 install path
         pip3 install pathlib2
-        pip3 install pyopenssl
-#       pip3 install pyopenssl==22.0.0
+        pip3 install pyopenssl==22.0.0
+        pip3 install cryptography==37.0.4 --ignore-installed
     - name: execute py script       # run mcd-scr-hk.py to get the latest data
       working-directory: ./mcd-scr-hk
       run: |

--- a/.github/workflows/scrape-hk-manual.yml
+++ b/.github/workflows/scrape-hk-manual.yml
@@ -22,19 +22,19 @@ jobs:
     - name: checkout repo content
       uses: actions/checkout@v3       # checkout the repository content to github runner.
     - name: setup python
-      uses: actions/setup-python@v4
-#       with:
-#         python-version: 3.8.2
+      uses: actions/setup-python@v5
+      with:
+          python-version: '3.12'
     - name: setup dependencies
       working-directory: ./mcd-scr-hk
       run: |
-        pip3 install scrapy==2.6.1
+        pip3 install scrapy==2.11.2
         pip3 install pandas 
         pip3 install pytz
         pip3 install path
         pip3 install pathlib2
-        pip3 install pyopenssl
-#       pip3 install pyopenssl==22.0.0
+        pip3 install pyopenssl==22.0.0
+        pip3 install cryptography==37.0.4 --ignore-installed
     - name: execute py script       # run mcd-scr-hk.py to get the latest data
       working-directory: ./mcd-scr-hk
       run: |

--- a/.github/workflows/scrape-ph-auto.yml
+++ b/.github/workflows/scrape-ph-auto.yml
@@ -24,9 +24,9 @@ jobs:
     - name: checkout repo content
       uses: actions/checkout@v3       # checkout the repository content to github runner.
     - name: setup python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
-         python-version: 3.12.0
+         python-version: '3.12'
     - name: setup dependencies
       working-directory: ./mcd-scr-ph
       run: |

--- a/.github/workflows/scrape-ph-auto.yml
+++ b/.github/workflows/scrape-ph-auto.yml
@@ -26,7 +26,7 @@ jobs:
     - name: setup python
       uses: actions/setup-python@v5
       with:
-         python-version: '3.12'
+        python-version: '3.12'
     - name: setup dependencies
       working-directory: ./mcd-scr-ph
       run: |

--- a/.github/workflows/scrape-ph-auto.yml
+++ b/.github/workflows/scrape-ph-auto.yml
@@ -25,18 +25,19 @@ jobs:
       uses: actions/checkout@v3       # checkout the repository content to github runner.
     - name: setup python
       uses: actions/setup-python@v4
-#       with:
-#         python-version: 3.8.2
+      with:
+         python-version: 3.12.0
     - name: setup dependencies
       working-directory: ./mcd-scr-ph
       run: |
-        pip3 install scrapy==2.6.1
+        pip3 install scrapy==2.11.2
         pip3 install pandas 
         pip3 install pytz
         pip3 install path
         pip3 install pathlib2
-        pip3 install pyopenssl
-#       pip3 install pyopenssl==22.0.0
+#        pip3 install pyopenssl
+       pip3 install pyopenssl==22.0.0
+       pip3 install cryptography==37.0.4 --ignore-installed
     - name: execute py script       # run mcd-scr-ph.py to get the latest data
       working-directory: ./mcd-scr-ph
       run: |

--- a/.github/workflows/scrape-ph-auto.yml
+++ b/.github/workflows/scrape-ph-auto.yml
@@ -35,9 +35,8 @@ jobs:
         pip3 install pytz
         pip3 install path
         pip3 install pathlib2
-#        pip3 install pyopenssl
-       pip3 install pyopenssl==22.0.0
-       pip3 install cryptography==37.0.4 --ignore-installed
+        pip3 install pyopenssl==22.0.0
+        pip3 install cryptography==37.0.4 --ignore-installed
     - name: execute py script       # run mcd-scr-ph.py to get the latest data
       working-directory: ./mcd-scr-ph
       run: |

--- a/.github/workflows/scrape-ph-manual.yml
+++ b/.github/workflows/scrape-ph-manual.yml
@@ -23,18 +23,18 @@ jobs:
             uses: actions/checkout@v3 # checkout the repository content to github runner.
           - name: setup python
             uses: actions/setup-python@v4
-#             with:
-#                 python-version: 3.8.2
+            with:
+                python-version: 3.12.0
           - name: setup dependencies
             working-directory: ./mcd-scr-ph
             run: |
-              pip3 install scrapy==2.6.1
+              pip3 install scrapy==2.11.2
               pip3 install pandas 
               pip3 install pytz
               pip3 install path
               pip3 install pathlib2
-              pip3 install pyopenssl
-#             pip3 install pyopenssl==22.0.0
+              pip3 install pyopenssl==22.0.0
+              pip3 install cryptography==37.0.4 --ignore-installed
           - name: execute py script # run mcd-scr-ph.py to get the latest data
             working-directory: ./mcd-scr-ph
             run: |

--- a/.github/workflows/scrape-ph-manual.yml
+++ b/.github/workflows/scrape-ph-manual.yml
@@ -22,9 +22,9 @@ jobs:
           - name: checkout repo content
             uses: actions/checkout@v3 # checkout the repository content to github runner.
           - name: setup python
-            uses: actions/setup-python@v4
+            uses: actions/setup-python@v5
             with:
-                python-version: 3.12.0
+                python-version: '3.12'
           - name: setup dependencies
             working-directory: ./mcd-scr-ph
             run: |

--- a/mcd-scr-hk/mcd/spiders/mcd-scr-hk.py
+++ b/mcd-scr-hk/mcd/spiders/mcd-scr-hk.py
@@ -87,7 +87,7 @@ class McdScrHkSpider(scrapy.Spider):
 		url = "https://hk.fd-api.com/api/v5/vendors/q8hc?include=menus,bundles,multiple_discounts&language_id=1&dynamic_pricing=0&opening_type=delivery&basket_currency=HKD"
 
 		headers = {
-			':authority': 'hk.fd-api.com',
+			'authority': 'hk.fd-api.com',
 			'accept': '''application/json,application/xhtml+xml,application/xml;q=0.9,
 			image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9''',
 			'accept-language': 'en-GB,en;q=0.9',

--- a/mcd-scr-hk/scraped-data/[2025-03-22 19:34:39] mcd-scr-hk.csv
+++ b/mcd-scr-hk/scraped-data/[2025-03-22 19:34:39] mcd-scr-hk.csv
@@ -1,0 +1,52 @@
+,Date,Day,Territory,Menu Item,Price (HKD),Price (USD),Category,Menu
+1,2025/03/22,Sat,Hong Kong,Shogun Burger Combo for 2,130.00,15.60,Shogun Burger,Regular Menu
+2,2025/03/22,Sat,Hong Kong,Crispy Thighs Sharing Bucket Combo for 3,183.00,21.96,Hot Deal,Regular Menu
+3,2025/03/22,Sat,Hong Kong,Crispy Thighs Sharing Bucket Combo for 2,128.00,15.36,Hot Deal,Regular Menu
+4,2025/03/22,Sat,Hong Kong,Crispy Thighs Combo for 1,70.00,8.40,Hot Deal,Regular Menu
+5,2025/03/22,Sat,Hong Kong,Burger Lovers Combo for 3,159.00,19.08,Hot Deal,Regular Menu
+6,2025/03/22,Sat,Hong Kong,Burger Lovers Combo for 2,115.00,13.80,Hot Deal,Regular Menu
+7,2025/03/22,Sat,Hong Kong,Burger Lover Combo for 1,56.00,6.72,Hot Deal,Regular Menu
+8,2025/03/22,Sat,Hong Kong,Happy Family Combo,139.00,16.68,Hot Deal,Regular Menu
+9,2025/03/22,Sat,Hong Kong,McWings (4pcs) Combo for 1,63.00,7.56,Hot Deal,Regular Menu
+10,2025/03/22,Sat,Hong Kong,McNuggets®(9pcs)Combo for 1,63.00,7.56,Hot Deal,Regular Menu
+11,2025/03/22,Sat,Hong Kong,Big Mac®,26.50,3.18,Regular A-la-carte,Regular Menu
+12,2025/03/22,Sat,Hong Kong,Double Cheeseburger™,25.00,3.00,Regular A-la-carte,Regular Menu
+13,2025/03/22,Sat,Hong Kong,Sausage McMuffin® with Egg,23.50,2.82,Regular A-la-carte,Regular Menu
+14,2025/03/22,Sat,Hong Kong,Filet-O-Fish™,24.00,2.88,Regular A-la-carte,Regular Menu
+15,2025/03/22,Sat,Hong Kong,Crispy Thighs(2pcs),42.50,5.10,Regular A-la-carte,Regular Menu
+16,2025/03/22,Sat,Hong Kong,Crispy Thighs (Original)Sharing Bucket (6pcs),113.50,13.62,Regular A-la-carte,Regular Menu
+17,2025/03/22,Sat,Hong Kong,Honey BBQ Crispy Thighs Sharing Bucket (6pcs),119.50,14.34,Regular A-la-carte,Regular Menu
+18,2025/03/22,Sat,Hong Kong,Original & Honey BBQ Crispy Thighs Sharing Bucket (6pcs),119.50,14.34,Regular A-la-carte,Regular Menu
+19,2025/03/22,Sat,Hong Kong,McWings®(4pcs),28.00,3.36,Regular A-la-carte,Regular Menu
+20,2025/03/22,Sat,Hong Kong,McWings®(6pcs),39.00,4.68,Regular A-la-carte,Regular Menu
+21,2025/03/22,Sat,Hong Kong,McWings® Sharing Bucket (16pcs),101.00,12.12,Regular A-la-carte,Regular Menu
+22,2025/03/22,Sat,Hong Kong,Chicken McNuggets® (6pcs),25.00,3.00,Regular A-la-carte,Regular Menu
+23,2025/03/22,Sat,Hong Kong,McNuggets®(18pcs),53.00,6.36,Regular A-la-carte,Regular Menu
+24,2025/03/22,Sat,Hong Kong,Tasty Sharing Box,45.00,5.40,Regular A-la-carte,Regular Menu
+25,2025/03/22,Sat,Hong Kong,Happy Meal® Chicken McNuggets® (4 pcs),36.00,4.32,Happy Meal,Regular Menu
+26,2025/03/22,Sat,Hong Kong,Happy Meal® Filet-O-Fish™,38.00,4.56,Happy Meal,Regular Menu
+27,2025/03/22,Sat,Hong Kong,Other Happy Meal Set,29.50,3.54,Happy Meal,Regular Menu
+28,2025/03/22,Sat,Hong Kong,McCafe Americano(L),35.00,4.20,McCafe Drink for McDelivery (Coffee brewed with 3.7 Fresh Milk),Regular Menu
+29,2025/03/22,Sat,Hong Kong,McCafe Iced Americano,40.00,4.80,McCafe Drink for McDelivery (Coffee brewed with 3.7 Fresh Milk),Regular Menu
+30,2025/03/22,Sat,Hong Kong,White Peach Soda with Fruit Cocktail,24.00,2.88,Beverages for McDelivery,Regular Menu
+31,2025/03/22,Sat,Hong Kong,Coca-Cola® (L),18.00,2.16,Beverages for McDelivery,Regular Menu
+32,2025/03/22,Sat,Hong Kong,Sprite® Lemon- Lime Flavored Soda (L),18.00,2.16,Beverages for McDelivery,Regular Menu
+33,2025/03/22,Sat,Hong Kong,Fanta® Orange Flavored Soda (L),18.00,2.16,Beverages for McDelivery,Regular Menu
+34,2025/03/22,Sat,Hong Kong,Coca-Cola® No Sugar (L),18.00,2.16,Beverages for McDelivery,Regular Menu
+35,2025/03/22,Sat,Hong Kong,McCafe Americano(L),35.00,4.20,Beverages for McDelivery,Regular Menu
+36,2025/03/22,Sat,Hong Kong,McCafe Iced Americano,40.00,4.80,Beverages for McDelivery,Regular Menu
+37,2025/03/22,Sat,Hong Kong,Hot Local Milk Tea,18.00,2.16,Beverages for McDelivery,Regular Menu
+38,2025/03/22,Sat,Hong Kong,Iced Local Milk Tea (L),23.00,2.76,Beverages for McDelivery,Regular Menu
+39,2025/03/22,Sat,Hong Kong,Hot Fresh Lemon Tea,18.00,2.16,Beverages for McDelivery,Regular Menu
+40,2025/03/22,Sat,Hong Kong,Iced Fresh Lemon Tea (L),23.00,2.76,Beverages for McDelivery,Regular Menu
+41,2025/03/22,Sat,Hong Kong,Minute Maid® Orange Juice (XL),19.50,2.34,Beverages for McDelivery,Regular Menu
+42,2025/03/22,Sat,Hong Kong,Hot Chocolate,18.00,2.16,Beverages for McDelivery,Regular Menu
+43,2025/03/22,Sat,Hong Kong,Apple Pie,14.00,1.68,Desserts,Regular Menu
+44,2025/03/22,Sat,Hong Kong,Hi-Calcium Low Fat Blueberry Yoghurt,16.00,1.92,Desserts,Regular Menu
+45,2025/03/22,Sat,Hong Kong,Corn Potage Flavored Seasoning,3.00,0.36,Extra/ Additional Sauce,Regular Menu
+46,2025/03/22,Sat,Hong Kong,Seaweed Seasoning,3.00,0.36,Extra/ Additional Sauce,Regular Menu
+47,2025/03/22,Sat,Hong Kong,Honey BBQ Seasoning,3.00,0.36,Extra/ Additional Sauce,Regular Menu
+48,2025/03/22,Sat,Hong Kong,Fries (M),18.00,2.16,Extra/ Additional Sauce,Regular Menu
+49,2025/03/22,Sat,Hong Kong,Fries (Large),21.00,2.52,Extra/ Additional Sauce,Regular Menu
+50,2025/03/22,Sat,Hong Kong,Thai Hot & Spicy Sauce,1.00,0.12,Extra/ Additional Sauce,Regular Menu
+51,2025/03/22,Sat,Hong Kong,Chicken McNuggets® Sauce,1.50,0.18,Extra/ Additional Sauce,Regular Menu

--- a/mcd-scr-ph/scraped-data/[2025-03-22 19:03:09] mcd-scr-ph.csv
+++ b/mcd-scr-ph/scraped-data/[2025-03-22 19:03:09] mcd-scr-ph.csv
@@ -1,0 +1,325 @@
+,Date,Day,Territory,Menu Item,Price (PHP),Price (USD),Category,Menu
+1,2025/03/22,Sat,Philippines,Double Big Mac Meal,331.00,3.31,McDelivery Exclusives,Regular
+2,2025/03/22,Sat,Philippines,Double McChicken Meal,248.00,2.48,McDelivery Exclusives,Regular
+3,2025/03/22,Sat,Philippines,Mega Meal - Chicken McDo w/ Fries & Burger McDo,221.00,2.21,McDelivery Exclusives,All Day
+4,2025/03/22,Sat,Philippines,Mega Meal - Chicken McDo w/ Fries & McFlurry,223.00,2.23,McDelivery Exclusives,All Day
+5,2025/03/22,Sat,Philippines,The BCB Meal,264.00,2.64,McDelivery Exclusives,Regular
+6,2025/03/22,Sat,Philippines,McSpaghetti Platter,259.00,2.59,Featured,Regular
+7,2025/03/22,Sat,Philippines,1-pc. Chicken McDo w/ Rice & Coke McFloat Meal,156.00,1.56,Featured,All Day
+8,2025/03/22,Sat,Philippines,Chili Con Carne Dunk Solo,50.00,0.50,Featured,Regular
+9,2025/03/22,Sat,Philippines,20-pc. Chicken McNuggets,350.00,3.50,Featured,Regular
+10,2025/03/22,Sat,Philippines,Snack Burger McShare,380.00,3.80,Featured,Regular
+11,2025/03/22,Sat,Philippines,BFF Fries N' McFloat Combo,282.00,2.82,Featured,Regular
+12,2025/03/22,Sat,Philippines,Big Breakfast Meal,182.00,1.82,Featured,Breakfast
+13,2025/03/22,Sat,Philippines,Sausage McMuffin w/ Egg Meal,170.00,1.70,Featured,Breakfast
+14,2025/03/22,Sat,Philippines,Egg McMuffin Meal,160.00,1.60,Featured,Breakfast
+15,2025/03/22,Sat,Philippines,2-pc. Hotcakes & Sausage Meal,174.00,1.74,Featured,Breakfast
+16,2025/03/22,Sat,Philippines,Longganisa w/ Egg Meal,190.00,1.90,Featured,Breakfast
+17,2025/03/22,Sat,Philippines,Cheeseburger with Dunk,186.00,1.86,Featured,Regular
+18,2025/03/22,Sat,Philippines,Double Cheeseburger with Dunk,289.00,2.89,Featured,Regular
+19,2025/03/22,Sat,Philippines,Cheesy Eggdesal with Hashbrowns Meal,113.00,1.13,Featured,Breakfast
+20,2025/03/22,Sat,Philippines,Sulit Busog - 1-pc. Chicken Mcdo Meal,99.00,0.99,Featured,Breakfast
+21,2025/03/22,Sat,Philippines,Sulit Busog - Longganisa with Egg Meal,99.00,0.99,Featured,Breakfast
+22,2025/03/22,Sat,Philippines,Sulit Busog - Crispy Chicken Fillet Ala King with Extra Rice Meal,99.00,0.99,Featured,Breakfast
+23,2025/03/22,Sat,Philippines,Sulit-Busog Crispy Chicken Fillet with Extra Rice and Regular Drink,99.00,0.99,Featured,Breakfast
+24,2025/03/22,Sat,Philippines,Sulit-Busog Crispy Chicken Fillet with Extra Rice and Regular Drink,99.00,0.99,Featured,Regular
+25,2025/03/22,Sat,Philippines,Sulit-Busog - 1-pc. Mushroom Pepper Steak with Extra Rice Meal,103.00,1.03,Featured,All Day
+26,2025/03/22,Sat,Philippines,Sulit-Busog - 1-pc. Chicken McDo with Extra Rice and Drink Meal,128.00,1.28,Featured,All Day
+27,2025/03/22,Sat,Philippines,Cheeseburger with Chili Con Carne Dunk Meal,186.00,1.86,Featured,Regular
+28,2025/03/22,Sat,Philippines,Double Cheeseburger with Chili Con Carne Dunk Meal,289.00,2.89,Featured,Regular
+29,2025/03/22,Sat,Philippines,McSpaghetti Platter,259.00,2.59,Group Meals,Regular
+30,2025/03/22,Sat,Philippines,20-pc. Chicken McNuggets,350.00,3.50,Group Meals,Regular
+31,2025/03/22,Sat,Philippines,Snack Burger McShare,380.00,3.80,Group Meals,Regular
+32,2025/03/22,Sat,Philippines,8-pc. Chicken McShare Box,651.00,6.51,Group Meals,Regular
+33,2025/03/22,Sat,Philippines,McShare Bundle for 3,612.00,6.12,Group Meals,Breakfast
+34,2025/03/22,Sat,Philippines,BFF Fries N' McFloat Combo,282.00,2.82,Group Meals,Regular
+35,2025/03/22,Sat,Philippines,BFF Shake Shake Fries BBQ N' McFloat Combo,284.00,2.84,Group Meals,All Day
+36,2025/03/22,Sat,Philippines,BFF Shake Shake Fries Cheese N' McFloat Combo,284.00,2.84,Group Meals,All Day
+37,2025/03/22,Sat,Philippines,McShare Bundle for 4,842.00,8.42,Group Meals,Breakfast
+38,2025/03/22,Sat,Philippines,McShare Bundle for 3,612.00,6.12,Group Meals,Regular
+39,2025/03/22,Sat,Philippines,McShare Bundle for 4,842.00,8.42,Group Meals,Regular
+40,2025/03/22,Sat,Philippines,10-pc. Chicken McNuggets,175.00,1.75,Group Meals,Regular
+41,2025/03/22,Sat,Philippines,6-pc. Chicken McShare Box,495.00,4.95,Group Meals,Breakfast
+42,2025/03/22,Sat,Philippines,6-pc. Chicken McShare Box,495.00,4.95,Group Meals,Regular
+43,2025/03/22,Sat,Philippines,8-pc. Chicken McShare Box,651.00,6.51,Group Meals,Breakfast
+44,2025/03/22,Sat,Philippines,1-pc. Chicken McDo w/ Rice & Coke McFloat Meal,156.00,1.56,Chicken,All Day
+45,2025/03/22,Sat,Philippines,Valentine's Day Food Package,299.00,2.99,Chicken,All Day
+46,2025/03/22,Sat,Philippines,8-pc. Chicken McShare Box,651.00,6.51,Chicken,Regular
+47,2025/03/22,Sat,Philippines,10-pc. Chicken McNuggets,175.00,1.75,Chicken,Regular
+48,2025/03/22,Sat,Philippines,6-pc. Chicken McShare Box,495.00,4.95,Chicken,Breakfast
+49,2025/03/22,Sat,Philippines,6-pc. Chicken McShare Box,495.00,4.95,Chicken,Regular
+50,2025/03/22,Sat,Philippines,6-pc. Chicken McNuggets,99.00,0.99,Chicken,Regular
+51,2025/03/22,Sat,Philippines,8-pc. Chicken McShare Box,651.00,6.51,Chicken,Breakfast
+52,2025/03/22,Sat,Philippines,2-pc. Chicken McDo Meal,229.00,2.29,Chicken,All Day
+53,2025/03/22,Sat,Philippines,2-pc. Spicy Chicken McDo Meal,241.00,2.41,Chicken,Regular
+54,2025/03/22,Sat,Philippines,1-pc. Spicy Chicken McDo Meal,145.00,1.45,Chicken,Regular
+55,2025/03/22,Sat,Philippines,Mega Meal - Spicy Chicken McDo w/ Rice & McSpaghetti,219.00,2.19,Chicken,Regular
+56,2025/03/22,Sat,Philippines,1-pc. Chicken McDo w/ McSpaghetti Meal,195.00,1.95,Chicken,Regular
+57,2025/03/22,Sat,Philippines,Mega Meal - Chicken McDo w/ Rice & McSpaghetti,215.00,2.15,Chicken,Regular
+58,2025/03/22,Sat,Philippines,1-pc. Chicken McDo Meal,139.00,1.39,Chicken,All Day
+59,2025/03/22,Sat,Philippines,1-pc. Spicy Chicken McDo w/ McSpaghetti Meal,201.00,2.01,Chicken,Regular
+60,2025/03/22,Sat,Philippines,6-pc. Chicken McNuggets w/ Rice Meal,182.00,1.82,Chicken,Regular
+61,2025/03/22,Sat,Philippines,1-pc. Chicken McDo & Fries Meal,176.00,1.76,Chicken,All Day
+62,2025/03/22,Sat,Philippines,1-pc. Spicy Chicken McDo & Fries Meal,182.00,1.82,Chicken,Regular
+63,2025/03/22,Sat,Philippines,Crispy Chicken Fillet w/ Fries Meal,156.00,1.56,Chicken,All Day
+64,2025/03/22,Sat,Philippines,Crispy Chicken Fillet Ala King w/ Fries Meal,163.00,1.63,Chicken,All Day
+65,2025/03/22,Sat,Philippines,6-pc. Chicken McNuggets w/ Fries Meal,203.00,2.03,Chicken,Regular
+66,2025/03/22,Sat,Philippines,Mega Meal - Chicken McDo w/ Fries & Burger McDo,221.00,2.21,Chicken,All Day
+67,2025/03/22,Sat,Philippines,Mega Meal - Chicken McDo w/ Fries & McFlurry,223.00,2.23,Chicken,All Day
+68,2025/03/22,Sat,Philippines,Mega Meal - Spicy Chicken McDo w/ Fries & McFlurry,227.00,2.27,Chicken,Regular
+69,2025/03/22,Sat,Philippines,Mega Meal - Spicy Chicken McDo w/ Fries & Burger McDo,225.00,2.25,Chicken,Regular
+70,2025/03/22,Sat,Philippines,2-pc. Chicken McDo & Fries Meal,281.00,2.81,Chicken,All Day
+71,2025/03/22,Sat,Philippines,2-pc. Spicy Chicken McDo & Fries Meal,293.00,2.93,Chicken,Regular
+72,2025/03/22,Sat,Philippines,1-pc. Chicken McDo w/ McSpaghetti & Fries Meal,251.00,2.51,Chicken,Regular
+73,2025/03/22,Sat,Philippines,1-pc. Spicy Chicken McDo w/ McSpaghetti & Fries Meal,257.00,2.57,Chicken,Regular
+74,2025/03/22,Sat,Philippines,Sulit-Busog 1-pc Chicken McDo with drink,129.00,1.29,Chicken,Regular
+75,2025/03/22,Sat,Philippines,Sulit-Busog Crispy Chicken Fillet Ala King w Extra Rice,99.00,0.99,Chicken,Regular
+76,2025/03/22,Sat,Philippines,Sulit Busog - 1-pc. Chicken Mcdo Meal,99.00,0.99,Chicken,Breakfast
+77,2025/03/22,Sat,Philippines,Sulit Busog - Crispy Chicken Fillet Ala King with Extra Rice Meal,99.00,0.99,Chicken,Breakfast
+78,2025/03/22,Sat,Philippines,Sulit-Busog Crispy Chicken Fillet with Extra Rice and Regular Drink,99.00,0.99,Chicken,Breakfast
+79,2025/03/22,Sat,Philippines,Sulit-Busog Crispy Chicken Fillet with Extra Rice and Regular Drink,99.00,0.99,Chicken,Regular
+80,2025/03/22,Sat,Philippines,Sulit-Busog - 1-pc. Chicken McDo with Extra Rice and Drink Meal,128.00,1.28,Chicken,All Day
+81,2025/03/22,Sat,Philippines,Big Mac Meal,271.00,2.71,Burgers,Regular
+82,2025/03/22,Sat,Philippines,Burger McDo Meal,143.00,1.43,Burgers,Regular
+83,2025/03/22,Sat,Philippines,Cheesy Burger McDo Meal,143.00,1.43,Burgers,Regular
+84,2025/03/22,Sat,Philippines,Cheeseburger Meal,173.00,1.73,Burgers,Regular
+85,2025/03/22,Sat,Philippines,Double Cheeseburger Meal,227.00,2.27,Burgers,Regular
+86,2025/03/22,Sat,Philippines,McChicken Meal,215.00,2.15,Burgers,Regular
+87,2025/03/22,Sat,Philippines,Quarter Pounder w/ Cheese Meal,271.00,2.71,Burgers,Regular
+88,2025/03/22,Sat,Philippines,Double Big Mac Meal,331.00,3.31,Burgers,Regular
+89,2025/03/22,Sat,Philippines,Double Quarter Pounder w/ Cheese Meal,327.00,3.27,Burgers,Regular
+90,2025/03/22,Sat,Philippines,Triple Cheeseburger Meal,273.00,2.73,Burgers,Regular
+91,2025/03/22,Sat,Philippines,Double McChicken Meal,248.00,2.48,Burgers,Regular
+92,2025/03/22,Sat,Philippines,Crispy Chicken Fillet Sandwich w/ Fries Meal,160.00,1.60,Burgers,Regular
+93,2025/03/22,Sat,Philippines,The BCB Meal,264.00,2.64,Burgers,Regular
+94,2025/03/22,Sat,Philippines,Burger McDo w/ Lettuce & Tomatoes Meal,178.00,1.78,Burgers,Regular
+95,2025/03/22,Sat,Philippines,Crispy Chicken Sandwich w/ Lettuce & Tomatoes Meal,195.00,1.95,Burgers,Regular
+96,2025/03/22,Sat,Philippines,Double Cheeseburger w/ Lettuce & Tomatoes Meal,262.00,2.62,Burgers,Regular
+97,2025/03/22,Sat,Philippines,"Quarter Pounder w/ Cheese, Lettuce, & Tomatoes Meal",306.00,3.06,Burgers,Regular
+98,2025/03/22,Sat,Philippines,Cheeseburger with Dunk,186.00,1.86,Burgers,Regular
+99,2025/03/22,Sat,Philippines,Double Cheeseburger with Dunk,289.00,2.89,Burgers,Regular
+100,2025/03/22,Sat,Philippines,Cheeseburger w/ Lettuce & Tomatoes,208.00,2.08,Burgers,Regular
+101,2025/03/22,Sat,Philippines,Cheesburger with regular fries,145.00,1.45,Burgers,Regular
+102,2025/03/22,Sat,Philippines,Burger McDo Meal,143.00,1.43,Burgers,Breakfast
+103,2025/03/22,Sat,Philippines,Cheesy Burger McDo Meal,143.00,1.43,Burgers,Breakfast
+104,2025/03/22,Sat,Philippines,Crispy Chicken Fillet Sandwich w/ Fries Meal,160.00,1.60,Burgers,Breakfast
+105,2025/03/22,Sat,Philippines,Cheeseburger with Chili Con Carne Dunk Meal,186.00,1.86,Burgers,Regular
+106,2025/03/22,Sat,Philippines,Double Cheeseburger with Chili Con Carne Dunk Meal,289.00,2.89,Burgers,Regular
+107,2025/03/22,Sat,Philippines,McSpaghetti w/ Burger McDo Meal,142.00,1.42,McSpaghetti,Regular
+108,2025/03/22,Sat,Philippines,McSpaghetti Meal,99.00,0.99,McSpaghetti,Regular
+109,2025/03/22,Sat,Philippines,Mega Meal - Spicy Chicken McDo w/ Rice & McSpaghetti,219.00,2.19,McSpaghetti,Regular
+110,2025/03/22,Sat,Philippines,1-pc. Chicken McDo w/ McSpaghetti Meal,195.00,1.95,McSpaghetti,Regular
+111,2025/03/22,Sat,Philippines,Mega Meal - Chicken McDo w/ Rice & McSpaghetti,215.00,2.15,McSpaghetti,Regular
+112,2025/03/22,Sat,Philippines,1-pc. Spicy Chicken McDo w/ McSpaghetti Meal,201.00,2.01,McSpaghetti,Regular
+113,2025/03/22,Sat,Philippines,McSpaghetti w/ Fries Meal,163.00,1.63,McSpaghetti,Regular
+114,2025/03/22,Sat,Philippines,1-pc. Chicken McDo w/ McSpaghetti & Fries Meal,251.00,2.51,McSpaghetti,Regular
+115,2025/03/22,Sat,Philippines,1-pc. Spicy Chicken McDo w/ McSpaghetti & Fries Meal,257.00,2.57,McSpaghetti,Regular
+116,2025/03/22,Sat,Philippines,2-pc. Mushroom Pepper Steak w/ Egg Meal,212.00,2.12,Rice Bowls,Breakfast
+117,2025/03/22,Sat,Philippines,1-pc. Mushroom Pepper Steak w/ Egg Meal,182.00,1.82,Rice Bowls,Breakfast
+118,2025/03/22,Sat,Philippines,2-pc. Mushroom Pepper Steak & Fries Meal,201.00,2.01,Rice Bowls,Regular
+119,2025/03/22,Sat,Philippines,1-pc. Mushroom Pepper Steak & Fries Meal,147.00,1.47,Rice Bowls,Regular
+120,2025/03/22,Sat,Philippines,1-pc. Mushroom Pepper Steak with Fries Meal,119.00,1.19,Rice Bowls,All Day
+121,2025/03/22,Sat,Philippines,Sulit-Busog - 1-pc. Mushroom Pepper Steak with Extra Rice Meal,103.00,1.03,Rice Bowls,All Day
+122,2025/03/22,Sat,Philippines,McFlurry® with Oreo®,62.00,0.62,Desserts & Drinks,All Day
+123,2025/03/22,Sat,Philippines,Apple Pie,43.00,0.43,Desserts & Drinks,All Day
+124,2025/03/22,Sat,Philippines,Hot Fudge Sundae,55.00,0.55,Desserts & Drinks,All Day
+125,2025/03/22,Sat,Philippines,Hot Caramel Sundae,55.00,0.55,Desserts & Drinks,All Day
+126,2025/03/22,Sat,Philippines,Coke McFloat,57.00,0.57,Desserts & Drinks,All Day
+127,2025/03/22,Sat,Philippines,Coke,75.00,0.75,Desserts & Drinks,All Day
+128,2025/03/22,Sat,Philippines,Coke Zero,75.00,0.75,Desserts & Drinks,All Day
+129,2025/03/22,Sat,Philippines,Sprite,75.00,0.75,Desserts & Drinks,All Day
+130,2025/03/22,Sat,Philippines,Orange Juice,82.00,0.82,Desserts & Drinks,All Day
+131,2025/03/22,Sat,Philippines,Iced Tea,82.00,0.82,Desserts & Drinks,All Day
+132,2025/03/22,Sat,Philippines,Apple Juice,82.00,0.82,Desserts & Drinks,All Day
+133,2025/03/22,Sat,Philippines,Choco Chip Cookies,80.00,0.80,McCafé,All Day
+134,2025/03/22,Sat,Philippines,Oreo Cheesecake,170.00,1.70,McCafé,All Day
+135,2025/03/22,Sat,Philippines,Dark Chocolate Cake,150.00,1.50,McCafé,All Day
+136,2025/03/22,Sat,Philippines,Blueberry Cheesecake,170.00,1.70,McCafé,All Day
+137,2025/03/22,Sat,Philippines,Sausage Croissant,130.00,1.30,McCafé,All Day
+138,2025/03/22,Sat,Philippines,Chicken Pesto Wrap,175.00,1.75,McCafé,All Day
+139,2025/03/22,Sat,Philippines,Cheese and Bacon Croissant,135.00,1.35,McCafé,All Day
+140,2025/03/22,Sat,Philippines,Caramel Cinnamon,110.00,1.10,McCafé,All Day
+141,2025/03/22,Sat,Philippines,Choco Chip Banana Slice,85.00,0.85,McCafé,All Day
+142,2025/03/22,Sat,Philippines,Macchiato,95.00,0.95,McCafé,All Day
+143,2025/03/22,Sat,Philippines,Espresso,95.00,0.95,McCafé,All Day
+144,2025/03/22,Sat,Philippines,McCafé Black Tea,95.00,0.95,McCafé,All Day
+145,2025/03/22,Sat,Philippines,McCafé Peppermint Tea,95.00,0.95,McCafé,All Day
+146,2025/03/22,Sat,Philippines,McCafé Jasmine Tea,95.00,0.95,McCafé,All Day
+147,2025/03/22,Sat,Philippines,McCafé Premium Roast Coffee,57.00,0.57,McCafé,All Day
+148,2025/03/22,Sat,Philippines,McCafé Iced Coffee Vanilla,72.00,0.72,McCafé,All Day
+149,2025/03/22,Sat,Philippines,McCafé Iced Coffee Original,61.00,0.61,McCafé,All Day
+150,2025/03/22,Sat,Philippines,McCafé Iced Coffee Chocolate,72.00,0.72,McCafé,All Day
+151,2025/03/22,Sat,Philippines,Americano,135.00,1.35,McCafé,All Day
+152,2025/03/22,Sat,Philippines,Cappuccino,145.00,1.45,McCafé,All Day
+153,2025/03/22,Sat,Philippines,Café Latte,145.00,1.45,McCafé,All Day
+154,2025/03/22,Sat,Philippines,Flat White,145.00,1.45,McCafé,All Day
+155,2025/03/22,Sat,Philippines,Mochaccino,150.00,1.50,McCafé,All Day
+156,2025/03/22,Sat,Philippines,McCafé Iced Mocha,155.00,1.55,McCafé,All Day
+157,2025/03/22,Sat,Philippines,McCafé Iced Chocolate,145.00,1.45,McCafé,All Day
+158,2025/03/22,Sat,Philippines,McCafé Iced Latte,145.00,1.45,McCafé,All Day
+159,2025/03/22,Sat,Philippines,McCafé Iced Tea,125.00,1.25,McCafé,All Day
+160,2025/03/22,Sat,Philippines,McCafé Iced Americano,140.00,1.40,McCafé,All Day
+161,2025/03/22,Sat,Philippines,McCafé Strawberry Smoothie,155.00,1.55,McCafé,All Day
+162,2025/03/22,Sat,Philippines,McCafé Dalandan Smoothie,155.00,1.55,McCafé,All Day
+163,2025/03/22,Sat,Philippines,McCafé Double Choco Frappe,170.00,1.70,McCafé,All Day
+164,2025/03/22,Sat,Philippines,McCafé Mocha Frappe,165.00,1.65,McCafé,All Day
+165,2025/03/22,Sat,Philippines,McCafé Caramel Frappe,165.00,1.65,McCafé,All Day
+166,2025/03/22,Sat,Philippines,McCafé Mocha Oreo Frappe,175.00,1.75,McCafé,All Day
+167,2025/03/22,Sat,Philippines,McCafé Caramel Oreo Frappe,175.00,1.75,McCafé,All Day
+168,2025/03/22,Sat,Philippines,McCafé Strawberry Oreo Frappe,165.00,1.65,McCafé,All Day
+169,2025/03/22,Sat,Philippines,Premium Hot Chocolate,145.00,1.45,McCafé,Breakfast
+170,2025/03/22,Sat,Philippines,Americano,119.00,1.19,McCafé,All Day
+171,2025/03/22,Sat,Philippines,Cappuccino,129.00,1.29,McCafé,All Day
+172,2025/03/22,Sat,Philippines,Cafe Latte,129.00,1.29,McCafé,All Day
+173,2025/03/22,Sat,Philippines,Mochaccino,134.00,1.34,McCafé,All Day
+174,2025/03/22,Sat,Philippines,Iced Mocha,132.00,1.32,McCafé,All Day
+175,2025/03/22,Sat,Philippines,Iced Latte,122.00,1.22,McCafé,All Day
+176,2025/03/22,Sat,Philippines,Iced Americano,107.00,1.07,McCafé,All Day
+177,2025/03/22,Sat,Philippines,McCafé Iced Coffee Black Medium,56.00,0.56,McCafé,All Day
+178,2025/03/22,Sat,Philippines,McCafé Coffee Float,82.00,0.82,McCafé,All Day
+179,2025/03/22,Sat,Philippines,McCafé Cappuccino Medium,115.00,1.15,McCafé,All Day
+180,2025/03/22,Sat,Philippines,McCafé Americano Medium,104.00,1.04,McCafé,All Day
+181,2025/03/22,Sat,Philippines,McCafé Iced Americano Medium,110.00,1.10,McCafé,All Day
+182,2025/03/22,Sat,Philippines,McCafé Iced Latte Medium,115.00,1.15,McCafé,All Day
+183,2025/03/22,Sat,Philippines,McCafé Iced Mocha Medium,126.00,1.26,McCafé,All Day
+184,2025/03/22,Sat,Philippines,McCafé Mochaccino Medium,120.00,1.20,McCafé,All Day
+185,2025/03/22,Sat,Philippines,McCafé Hot Latte Medium,115.00,1.15,McCafé,All Day
+186,2025/03/22,Sat,Philippines,BFF Fries,169.00,1.69,Fries & Extras,All Day
+187,2025/03/22,Sat,Philippines,Extra Gravy,11.00,0.11,Fries & Extras,All Day
+188,2025/03/22,Sat,Philippines,Hash Browns,57.00,0.57,Fries & Extras,Breakfast
+189,2025/03/22,Sat,Philippines,Extra McSpaghetti Sauce,25.00,0.25,Fries & Extras,Regular
+190,2025/03/22,Sat,Philippines,Extra Cheese,17.00,0.17,Fries & Extras,All Day
+191,2025/03/22,Sat,Philippines,Extra Butter,11.00,0.11,Fries & Extras,Breakfast
+192,2025/03/22,Sat,Philippines,Extra Maple Syrup,11.00,0.11,Fries & Extras,Breakfast
+193,2025/03/22,Sat,Philippines,Extra Plain Rice,39.00,0.39,Fries & Extras,All Day
+194,2025/03/22,Sat,Philippines,Extra Mayonnaise,17.00,0.17,Fries & Extras,All Day
+195,2025/03/22,Sat,Philippines,Extra Crispy Chicken Fillet Ala King Sauce,11.00,0.11,Fries & Extras,All Day
+196,2025/03/22,Sat,Philippines,Extra Sweet N' Sour Sauce,17.00,0.17,Fries & Extras,All Day
+197,2025/03/22,Sat,Philippines,Extra BBQ Sauce,17.00,0.17,Fries & Extras,All Day
+198,2025/03/22,Sat,Philippines,Extra Mushroom Pepper Steak Sauce,11.00,0.11,Fries & Extras,Regular
+199,2025/03/22,Sat,Philippines,Extra Garlic Rice,46.00,0.46,Fries & Extras,Breakfast
+200,2025/03/22,Sat,Philippines,Tartar Sauce,17.00,0.17,Fries & Extras,Regular
+201,2025/03/22,Sat,Philippines,Thousand Island Sauce,18.00,0.18,Fries & Extras,Regular
+202,2025/03/22,Sat,Philippines,Cheese Dunk Solo,45.00,0.45,Fries & Extras,Regular
+203,2025/03/22,Sat,Philippines,Chili Con Carne Dunk Solo,50.00,0.50,Fries & Extras,Regular
+204,2025/03/22,Sat,Philippines,BFF Shake Shake Fries Cheese N' McFloat Combo,284.00,2.84,Fries & Extras,All Day
+205,2025/03/22,Sat,Philippines,BFF Shake Shake Fries BBQ N' McFloat Combo,284.00,2.84,Fries & Extras,All Day
+206,2025/03/22,Sat,Philippines,Large Fries N' McFloat Combo,135.00,1.35,Fries & Extras,All Day
+207,2025/03/22,Sat,Philippines,Shake Shake Fries BBQ N' McFloat Combo,123.00,1.23,Fries & Extras,All Day
+208,2025/03/22,Sat,Philippines,Large Shake Shake Fries BBQ N' McFloat Combo,148.00,1.48,Fries & Extras,All Day
+209,2025/03/22,Sat,Philippines,Shake Shake Fries Cheese N' McFloat Combo,123.00,1.23,Fries & Extras,All Day
+210,2025/03/22,Sat,Philippines,Large Shake Shake Fries Cheese N' McFloat Combo,148.00,1.48,Fries & Extras,All Day
+211,2025/03/22,Sat,Philippines,Shake Shake Fries BBQ,93.00,0.93,Fries & Extras,All Day
+212,2025/03/22,Sat,Philippines,Shake Shake Fries Cheese,93.00,0.93,Fries & Extras,All Day
+213,2025/03/22,Sat,Philippines,Fries,83.00,0.83,Fries & Extras,All Day
+214,2025/03/22,Sat,Philippines,4-pc. Chicken McNuggets Happy Meal,147.00,1.47,Happy Meal,Regular
+215,2025/03/22,Sat,Philippines,McSpaghetti Happy Meal,140.00,1.40,Happy Meal,Regular
+216,2025/03/22,Sat,Philippines,2-pc. Hotcakes Happy Meal,129.00,1.29,Happy Meal,Breakfast
+217,2025/03/22,Sat,Philippines,Burger McDo Happy Meal,129.00,1.29,Happy Meal,All Day
+218,2025/03/22,Sat,Philippines,1-pc. Chicken McDo Happy Meal,185.00,1.85,Happy Meal,All Day
+219,2025/03/22,Sat,Philippines,Sausage McMuffin w/ Egg Meal,170.00,1.70,BREAKFAST HOURS,Breakfast
+220,2025/03/22,Sat,Philippines,Longganisa w/ Egg Meal,190.00,1.90,BREAKFAST HOURS,Breakfast
+221,2025/03/22,Sat,Philippines,Burger McDo Meal,143.00,1.43,BREAKFAST HOURS,Regular
+222,2025/03/22,Sat,Philippines,Crispy Chicken Fillet Sandwich w/ Fries Meal,160.00,1.60,BREAKFAST HOURS,Regular
+223,2025/03/22,Sat,Philippines,2-pc. Hotcakes with Hashbrown Meal,137.00,1.37,BREAKFAST HOURS,Breakfast
+224,2025/03/22,Sat,Philippines,Burger McDo Meal,143.00,1.43,BREAKFAST HOURS,Breakfast
+225,2025/03/22,Sat,Philippines,Crispy Chicken Fillet Sandwich w/ Fries Meal,160.00,1.60,BREAKFAST HOURS,Breakfast
+226,2025/03/22,Sat,Philippines,10-pc. Chicken McNuggets,175.00,1.75,LUNCH HOURS,Regular
+227,2025/03/22,Sat,Philippines,6-pc. Chicken McNuggets,99.00,0.99,LUNCH HOURS,Regular
+228,2025/03/22,Sat,Philippines,McSpaghetti Meal,99.00,0.99,LUNCH HOURS,Regular
+229,2025/03/22,Sat,Philippines,Cheeseburger Meal,173.00,1.73,LUNCH HOURS,Regular
+230,2025/03/22,Sat,Philippines,1-pc. Mushroom Pepper Steak & Fries Meal,147.00,1.47,LUNCH HOURS,Regular
+231,2025/03/22,Sat,Philippines,10-pc. Chicken McNuggets,175.00,1.75,PM SNACK HOURS,Regular
+232,2025/03/22,Sat,Philippines,6-pc. Chicken McNuggets,99.00,0.99,PM SNACK HOURS,Regular
+233,2025/03/22,Sat,Philippines,McSpaghetti Meal,99.00,0.99,PM SNACK HOURS,Regular
+234,2025/03/22,Sat,Philippines,Cheeseburger Meal,173.00,1.73,PM SNACK HOURS,Regular
+235,2025/03/22,Sat,Philippines,1-pc. Mushroom Pepper Steak & Fries Meal,147.00,1.47,PM SNACK HOURS,Regular
+236,2025/03/22,Sat,Philippines,10-pc. Chicken McNuggets,175.00,1.75,DINNER HOURS,Regular
+237,2025/03/22,Sat,Philippines,6-pc. Chicken McNuggets,99.00,0.99,DINNER HOURS,Regular
+238,2025/03/22,Sat,Philippines,McSpaghetti Meal,99.00,0.99,DINNER HOURS,Regular
+239,2025/03/22,Sat,Philippines,Cheeseburger Meal,173.00,1.73,DINNER HOURS,Regular
+240,2025/03/22,Sat,Philippines,1-pc. Mushroom Pepper Steak & Fries Meal,147.00,1.47,DINNER HOURS,Regular
+241,2025/03/22,Sat,Philippines,10-pc. Chicken McNuggets,175.00,1.75,AFTER DINNER HOURS,Regular
+242,2025/03/22,Sat,Philippines,6-pc. Chicken McNuggets,99.00,0.99,AFTER DINNER HOURS,Regular
+243,2025/03/22,Sat,Philippines,McSpaghetti Meal,99.00,0.99,AFTER DINNER HOURS,Regular
+244,2025/03/22,Sat,Philippines,Cheeseburger Meal,173.00,1.73,AFTER DINNER HOURS,Regular
+245,2025/03/22,Sat,Philippines,1-pc. Mushroom Pepper Steak & Fries Meal,147.00,1.47,AFTER DINNER HOURS,Regular
+246,2025/03/22,Sat,Philippines,Hash Browns,57.00,0.57,,Breakfast
+247,2025/03/22,Sat,Philippines,Fries,83.00,0.83,Add-ons,All Day
+248,2025/03/22,Sat,Philippines,"Party Hats, Tray Mats, Balloons, and Classic Happy Meal Toys",50.00,0.50,,All Day
+249,2025/03/22,Sat,Philippines,Extra BBQ Powder,10.00,0.10,Add-ons,All Day
+250,2025/03/22,Sat,Philippines,Extra Cheese Powder,10.00,0.10,Add-ons,Breakfast
+251,2025/03/22,Sat,Philippines,McCrispy Chicken Sandwich Solo,64.00,0.64,Add-ons,All Day
+252,2025/03/22,Sat,Philippines,Shake Shake Fries BBQ,93.00,0.93,Add-ons,All Day
+253,2025/03/22,Sat,Philippines,Cheeseburger Solo,79.00,0.79,Add-ons,All Day
+254,2025/03/22,Sat,Philippines,Free 6-pc. Chicken McNuggets,0.00,0.00,Add-ons,All Day
+255,2025/03/22,Sat,Philippines,Shake Shake Fries Honey Butter,75.00,0.75,Add-ons,All Day
+256,2025/03/22,Sat,Philippines,Burger McDo Solo,44.00,0.44,Add-ons,All Day
+257,2025/03/22,Sat,Philippines,Coke McFloat,57.00,0.57,Add-ons,All Day
+258,2025/03/22,Sat,Philippines,Free Big Mac Solo,0.00,0.00,Add-ons,All Day
+259,2025/03/22,Sat,Philippines,Free Quarter Pounder with Cheese,0.00,0.00,Add-ons,All Day
+260,2025/03/22,Sat,Philippines,Free Cheeseburger Solo,0.00,0.00,Add-ons,All Day
+261,2025/03/22,Sat,Philippines,Extra Tomatoes,15.00,0.15,Add-ons,Regular
+262,2025/03/22,Sat,Philippines,Extra Lettuce & Tomatoes,35.00,0.35,Add-ons,Regular
+263,2025/03/22,Sat,Philippines,Free McCrispy Chicken Sandwich,0.00,0.00,Add-ons,All Day
+264,2025/03/22,Sat,Philippines,Free Double Cheeseburger,0.00,0.00,Add-ons,Regular
+265,2025/03/22,Sat,Philippines,Free Double Cheeseburger Small Meal,0.00,0.00,Add-ons,Regular
+266,2025/03/22,Sat,Philippines,Free McSpicy Solo,0.00,0.00,Add-ons,Regular
+267,2025/03/22,Sat,Philippines,Free 1pc Spicy Chicken McDo Small Meal,0.00,0.00,Add-ons,Regular
+268,2025/03/22,Sat,Philippines,Free Big Mac Solo,0.00,0.00,Add-ons,All Day
+269,2025/03/22,Sat,Philippines,Free Double Cheeseburger Solo,0.00,0.00,Add-ons,All Day
+270,2025/03/22,Sat,Philippines,Free Big Mac Solo,0.00,0.00,Add-ons,All Day
+271,2025/03/22,Sat,Philippines,Free Quarter Pounder w/ Cheese,0.00,0.00,Add-ons,All Day
+272,2025/03/22,Sat,Philippines,Free Double Cheeseburger,0.00,0.00,Add-ons,All Day
+273,2025/03/22,Sat,Philippines,Free McSpaghetti Platter,0.00,0.00,Add-ons,All Day
+274,2025/03/22,Sat,Philippines,Free McSpaghetti Platter,0.00,0.00,Add-ons,All Day
+275,2025/03/22,Sat,Philippines,Free Coke McFloat Medium,0.00,0.00,Add-ons,All Day
+276,2025/03/22,Sat,Philippines,Free Small Fries,0.00,0.00,Add-ons,All Day
+277,2025/03/22,Sat,Philippines,Free Medium Fries,0.00,0.00,Add-ons,All Day
+278,2025/03/22,Sat,Philippines,Add-on: BT21 Toy - Chimmy,150.00,1.50,Add-ons,All Day
+279,2025/03/22,Sat,Philippines,Add-on: BT21 Toy - Cooky,150.00,1.50,Add-ons,All Day
+280,2025/03/22,Sat,Philippines,Add-on: BT21 Toy - Koya,150.00,1.50,Add-ons,All Day
+281,2025/03/22,Sat,Philippines,Add-on: BT21 Toy - Mang,150.00,1.50,Add-ons,All Day
+282,2025/03/22,Sat,Philippines,Add-on: BT21 Toy - RJ,150.00,1.50,Add-ons,All Day
+283,2025/03/22,Sat,Philippines,Add-on: BT21 Toy - Shooky,150.00,1.50,Add-ons,All Day
+284,2025/03/22,Sat,Philippines,Add-on: BT21 Toy - Tata,150.00,1.50,Add-ons,All Day
+285,2025/03/22,Sat,Philippines,Regular Fries,55.00,0.55,Add-ons,All Day
+286,2025/03/22,Sat,Philippines,McCafé Iced Coffee Original,61.00,0.61,Add-ons,All Day
+287,2025/03/22,Sat,Philippines,Valentine's Day Food Package,299.00,2.99,,All Day
+288,2025/03/22,Sat,Philippines,Burgers Family Bundle,699.00,6.99,,Regular
+289,2025/03/22,Sat,Philippines,Extra Rice,25.00,0.25,Add-ons,All Day
+290,2025/03/22,Sat,Philippines,Add Milk,10.00,0.10,Add-ons,All Day
+291,2025/03/22,Sat,Philippines,Add Sugar Syrup,10.00,0.10,Add-ons,All Day
+292,2025/03/22,Sat,Philippines,Big Breakfast Meal,182.00,1.82,,Breakfast
+293,2025/03/22,Sat,Philippines,Sausage McMuffin w/ Egg Meal,170.00,1.70,,Breakfast
+294,2025/03/22,Sat,Philippines,Sausage McMuffin Meal,150.00,1.50,,Breakfast
+295,2025/03/22,Sat,Philippines,Egg McMuffin Meal,160.00,1.60,,Breakfast
+296,2025/03/22,Sat,Philippines,Cheesy Eggdesal w/ Sausage Meal,162.00,1.62,,Breakfast
+297,2025/03/22,Sat,Philippines,Cheesy Eggdesal w/ Ham Meal,154.00,1.54,,Breakfast
+298,2025/03/22,Sat,Philippines,2-pc. Hotcakes & Sausage Meal,174.00,1.74,,Breakfast
+299,2025/03/22,Sat,Philippines,2-pc. Mushroom Pepper Steak w/ Egg Meal,212.00,2.12,,Breakfast
+300,2025/03/22,Sat,Philippines,1-pc. Mushroom Pepper Steak w/ Egg Meal,182.00,1.82,,Breakfast
+301,2025/03/22,Sat,Philippines,Sausage w/ Egg Meal,190.00,1.90,,Breakfast
+302,2025/03/22,Sat,Philippines,Longganisa w/ Egg Meal,190.00,1.90,,Breakfast
+303,2025/03/22,Sat,Philippines,Crispy Chicken Fillet w/ Egg Meal,174.00,1.74,,Breakfast
+304,2025/03/22,Sat,Philippines,Crispy Chicken Fillet Ala King w/ Egg Meal,177.00,1.77,,Breakfast
+305,2025/03/22,Sat,Philippines,1-pc. Chicken McDo w/ Egg Meal,230.00,2.30,,Breakfast
+306,2025/03/22,Sat,Philippines,2-pc. Chicken McDo w/ Egg Meal,282.00,2.82,,Breakfast
+307,2025/03/22,Sat,Philippines,Double Big Mac Meal,331.00,3.31,,Regular
+308,2025/03/22,Sat,Philippines,Mega Meal - Chicken McDo w/ Fries & Burger McDo,221.00,2.21,,All Day
+309,2025/03/22,Sat,Philippines,Mega Meal - Chicken McDo w/ Fries & McFlurry,223.00,2.23,,All Day
+310,2025/03/22,Sat,Philippines,The BCB Meal,264.00,2.64,,Regular
+311,2025/03/22,Sat,Philippines,2-pc. Hotcakes with Hashbrown Meal,137.00,1.37,,Breakfast
+312,2025/03/22,Sat,Philippines,Sulit-Busog 1-pc Chicken McDo with drink,129.00,1.29,Sulit Busog Meals,Regular
+313,2025/03/22,Sat,Philippines,Sulit-Busog Crispy Chicken Fillet Ala King w Extra Rice,99.00,0.99,Sulit Busog Meals,Regular
+314,2025/03/22,Sat,Philippines,Cheesy Eggdesal with Hashbrowns Meal,113.00,1.13,,Breakfast
+315,2025/03/22,Sat,Philippines,Sulit Busog - 1-pc. Chicken Mcdo Meal,99.00,0.99,Sulit Busog Meals,Breakfast
+316,2025/03/22,Sat,Philippines,Sulit Busog - Longganisa with Egg Meal,99.00,0.99,,Breakfast
+317,2025/03/22,Sat,Philippines,Sulit Busog - Longganisa with Egg Meal,99.00,0.99,Sulit Busog Meals,Breakfast
+318,2025/03/22,Sat,Philippines,Sulit Busog - Crispy Chicken Fillet Ala King with Extra Rice Meal,99.00,0.99,Sulit Busog Meals,Breakfast
+319,2025/03/22,Sat,Philippines,Sulit-Busog Crispy Chicken Fillet with Extra Rice and Regular Drink,99.00,0.99,,Breakfast
+320,2025/03/22,Sat,Philippines,Sulit-Busog Crispy Chicken Fillet with Extra Rice and Regular Drink,99.00,0.99,Sulit Busog Meals,Breakfast
+321,2025/03/22,Sat,Philippines,Sulit-Busog Crispy Chicken Fillet with Extra Rice and Regular Drink,99.00,0.99,,Regular
+322,2025/03/22,Sat,Philippines,Sulit-Busog Crispy Chicken Fillet with Extra Rice and Regular Drink,99.00,0.99,Sulit Busog Meals,Regular
+323,2025/03/22,Sat,Philippines,Sulit-Busog - 1-pc. Mushroom Pepper Steak with Extra Rice Meal,103.00,1.03,Sulit Busog Meals,All Day
+324,2025/03/22,Sat,Philippines,Sulit-Busog - 1-pc. Chicken McDo with Extra Rice and Drink Meal,128.00,1.28,Sulit Busog Meals,All Day


### PR DESCRIPTION
## Problem

Missing methods for OpenSSL v3 when called by Scrapy.

![Screenshot_2025-03-22_12-51-34](https://github.com/user-attachments/assets/7846de56-b39d-48ed-a650-b21e3c207eb5)


## Fix

Python version updated to `3.12`

```bash
    - name: setup python
      uses: actions/setup-python@v5
      with:
        python-version: '3.12'
```

1. Updated to use `scrapy` version `2.11.2`
2. To avoid OpenSSL issues, use version 22.0.0 of `pyopenssl`
and downgrade `cryptography` to `<38`

```bash
pip3 install scrapy==2.11.2
pip3 install pandas 
pip3 install pytz
pip3 install path
pip3 install pathlib2
pip3 install pyopenssl==22.0.0
pip3 install cryptography==37.0.4 --ignore-installed
```

Now there are no more conflicts or missing methods.